### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -1,3 +1,3 @@
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 
 export const useTenant = () => useNuxtApp().$tenant

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from "#app";
+import { defineNuxtPlugin } from "#imports";
 import { useRequestURL, useRuntimeConfig } from "nuxt/app";
 
 export default defineNuxtPlugin(() => {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.