### PR TITLE
fix: restrict `sites` subdomains to only their own route subtree

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -83,6 +83,7 @@ export default defineNuxtModule<ModuleOptions>({
           if (sites.has(tenant)) {
             return routes
               .filter(ignoreDynamicRoute)
+              .filter(route => route.path.startsWith('/' + tenant))
               .map((route) => rewritePrefixRoute(route, '/' + tenant));
           }
 


### PR DESCRIPTION
## Summary

* **Before:** In the `sites.has(tenant)` branch, routes were rewritten but **not filtered**, so non-tenant routes (e.g. `/about`) could appear on `jobs.example.com`.
* **Change:** Add `filter(route => route.path.startsWith('/' + tenant))` before rewriting.
* **Result:** `jobs.example.com` now serves **only** `/jobs/**`.

## Question

* Was the previous behavior (serving all routes on a `sites` subdomain) intentional? If yes, should this become an opt-in (e.g. `isolateSiteSubtrees: true`) instead of the default?
