### PR TITLE
feat: add `strictSubdomains` option to control subdomain tenant parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,22 @@ export default defineNuxtConfig({
 })
 ```
 
-5. If you want to custom domain for each tenant route, configure the `customDomains` property a map with key of domain and value of mapping tenant route. For example: `nuxtnews.com` to `news` route.
+5. If you are using a hoster that provides preview environments with temporary domains including subdomains (e.g. `jobs.project-name-hash.example-hoster.com`), you can also disable the strict subdomain check, so only the first subdomain is used as the tenant (e.g. `foo.bar.baz.dev` → `foo`) and an exact match is not required (i.e. site + root domain).
+
+```js
+export default defineNuxtConfig({
+  modules: ['nuxt-multi-tenancy'],
+  multiTenancy: {
+    tenantDynamicRoute: 'site',
+    rootDomains: ["nuxtdev.local", "techgoda.net", "example-hoster.com"],
+    strictSubdomains: false
+    sites: ['jobs']
+  },
+})
+```
+
+
+6. If you want to custom domain for each tenant route, configure the `customDomains` property a map with key of domain and value of mapping tenant route. For example: `nuxtnews.com` to `news` route.
 
 ```js
 export default defineNuxtConfig({
@@ -90,6 +105,7 @@ export default defineNuxtConfig({
   multiTenancy: {
     tenantDynamicRoute: 'site',
     rootDomains: ["nuxtdev.local", "techgoda.net"],
+    strictSubdomains: true,
     sites: [],
     customDomains: {},
   },
@@ -104,8 +120,6 @@ Use useTenant() to get the tenant ID
 import { useTenant } from '#imports'
 const tenant = useTenant()
 ```
-
-
 
 
 ## Development

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,6 +9,7 @@ import {
 export interface ModuleOptions {
   tenantDynamicRoute?: string;
   rootDomains: string[];
+  strictSubdomains?: boolean;
   sites?: string[];
   customDomains?: Record<string, string>;
 }
@@ -23,13 +24,15 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     tenantDynamicRoute: "site",
     rootDomains: ["localhost"],
+    strictSubdomains: true,
     sites: [],
     customDomains: {},
   },
-  setup({ tenantDynamicRoute, rootDomains, sites, customDomains }, nuxt) {
+  setup({ tenantDynamicRoute, rootDomains, strictSubdomains, sites, customDomains }, nuxt) {
     nuxt.options.runtimeConfig.public = {
       ...nuxt.options.runtimeConfig.public,
       rootDomains,
+      strictSubdomains,
     };
     const resolver = createResolver(import.meta.url);
     addPlugin(resolver.resolve("./runtime/plugin"));
@@ -68,8 +71,8 @@ export default defineNuxtModule<ModuleOptions>({
           }
 
           const rootDomain = ${JSON.stringify(
-            rootDomains
-          )}.find(domain => hostname.endsWith(domain));
+        rootDomains
+      )}.find(domain => hostname.endsWith(domain));
 
           if (!rootDomain) {
             return routes;
@@ -78,7 +81,14 @@ export default defineNuxtModule<ModuleOptions>({
             return routes.filter(ignoreDynamicRoute).filter(ignoreTenantSitesRoute);
           }
 
-          const tenant = hostname.substring(0, hostname.indexOf(rootDomain) - 1);
+          let subdomain;
+          if (${strictSubdomains}) {
+            subdomain = hostname.substring(0, hostname.indexOf(rootDomain) - 1);
+          } else {
+            subdomain = hostname.split('.')[0];
+          }
+
+          const tenant = subdomain;
 
           if (sites.has(tenant)) {
             return routes

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -15,8 +15,13 @@ export default defineNuxtPlugin(() => {
       },
     };
   }
-  const idx = hostname.indexOf(rootDomain);
-  const tenant = hostname.substring(0, idx - 1);
+  let subdomain;
+  if (config.public.strictSubdomains) {
+    subdomain = hostname.substring(0, hostname.indexOf(rootDomain) - 1);
+  } else {
+    subdomain = hostname.split(".")[0];
+  }
+  const tenant = subdomain;
 
   return {
     provide: {


### PR DESCRIPTION
## Summary

Introduce a new `strictSubdomains` boolean (default **true**) that lets apps choose how a tenant is derived from multi-level subdomains:

* **`strictSubdomains: true` (default, backward-compatible):** use the full left-hand side before the root domain.
  `foo.bar.baz.dev` → tenant `"foo.bar"` (root domain: `baz.dev`)
* **`strictSubdomains: false`:** use only the first label.
  `foo.bar.baz.dev` → tenant `"foo"`

The option is applied consistently in:

* the generated `tenant-router.options.mjs` (route matching/rewriting), and
* the runtime plugin used by `useTenant()` (so composables/components see the same tenant the router uses).

## Rationale

Some deployments want sub-subdomains to resolve to the same tenant as their first label (e.g., `foo.*.baz.dev` → `"foo"`). This flag enables that without breaking existing setups. This has been originally developped for a setup on `platform.sh` which provides `example.<branch>-<hash>-<project>.<region>.platformsh.site` domains for preview environments. With this change you can event route subdomains that do not exactly match (site + root domain).

> [!NOTE]
> Other hosters have solved this differently. For example Vercel uses the pattern like `tenant1---project-name-git-branch.yourdomain.dev` for their multi-tenant preview URLs (enterprise feature). Parsing `---` in subdomains instead of `.` could also be added in the future.

## Implementation

* Add `strictSubdomains?: boolean` to module options; default to `true`.
* Expose it via `runtimeConfig.public`.
* Use it to select between:

  ```js
  // strict = true (existing behavior)
  hostname.substring(0, hostname.indexOf(rootDomain) - 1)
  // strict = false (new behavior)
  hostname.split('.')[0]
  ```

  in both the router options template and the runtime plugin.

## Behavior / Compatibility

* **Default preserves current behavior.** No breaking changes for existing users.
* When disabled, multi-level subdomains collapse to the first label.
